### PR TITLE
fix:无法监听 fileList 变化

### DIFF
--- a/core/components/UploadList.vue
+++ b/core/components/UploadList.vue
@@ -25,7 +25,7 @@
   </transition-group>
 </template>
 <script setup>
-import { ref, defineProps, defineEmits, onMounted, computed } from "vue";
+import { ref, defineProps, defineEmits, onMounted, computed, watch } from "vue";
 import Upload from "./upload.vue";
 
 const emit = defineEmits(["change", "delete", "progress", "success", "error"]);
@@ -60,7 +60,12 @@ const props = defineProps({
 });
 
 const list = ref(props.fileList);
-
+watch(
+  () => props.fileList,
+  () => {
+    list.value = props.fileList;
+  }
+);
 let lastDragOverTimestamp = 0;
 
 let time = 200;


### PR DESCRIPTION
在 onMounted 中 修改 fileList 页面中显示的fileList 没有发生改变